### PR TITLE
feat(index): add support for extracting words for teaser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7179,6 +7179,11 @@
         }
       }
     },
+    "jsep": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.4.tgz",
+      "integrity": "sha512-ovGD9wE+wvudIIYxZGrRcZCxNyZ3Cl1N7Bzyp7/j4d/tA0BaUwcVM9bu0oZaSrefMiNwv6TwZ9X15gvZosteCQ=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@adobe/helix-pipeline": "6.1.5",
     "fs-extra": "8.1.0",
     "jsdom": "15.2.1",
+    "jsep": "^0.3.4",
     "mdast-util-to-string": "1.0.7",
     "moment": "2.24.0",
     "request": "2.88.0",

--- a/test/html_json.test.js
+++ b/test/html_json.test.js
@@ -46,7 +46,9 @@ describe('HTML Indexing', () => {
     const up = new UpCommand()
       .withFiles(['src/*.js'])
       .withLocalRepo(['.'])
+      .withHttpPort(0)
       .withTargetDir(testRoot);
+
     const started = eventPromise(up, 'started');
     const stopped = eventPromise(up, 'stopped');
     try {

--- a/test/specs/blog/helix-index.yaml
+++ b/test/specs/blog/helix-index.yaml
@@ -8,27 +8,31 @@ indices:
       author:
         select: main > div:nth-of-type(3) > p:nth-of-type(1)
         value: |
-          ${match('by (.*)')}
+          match(el, 'by (.*)')
         faceted: true
       title:
         select: h1:first-of-type
         value: |
-          ${textContent()}
+          textContent(el)
       date:
         select: main > div:nth-of-type(3)
         value: |
-          ${parseTimestamp('[POSTED ON] MM-DD-YYYY')}
+          parseTimestamp(el, '[POSTED ON] MM-DD-YYYY')
       topics:
         select: main > div:last-of-type > p:first-of-type
-        value: |
-          ${match('(Topics: )? ([^,]+)')}
+        values: |
+          match(el, '(Topics: )? ([^,]+)')
         faceted: true
       products:
         select: main > div:last-of-type > p:nth-of-type(2)
-        value: |
-          ${match('(Products: )? ([^,]+)')}
+        values: |
+          match(el, '(Products: )? ([^,]+)')
         faceted: true
       hero:
         select: main > div > img:first-of-type
         value: |
-          ${attribute('src')}
+          attribute(el, 'src')
+      teaser:
+        select: main > div:nth-last-of-type(-n+3) p
+        value: |
+          words(textContent(el), 0, 5)

--- a/test/specs/blog/post1_html.json
+++ b/test/specs/blog/post1_html.json
@@ -10,6 +10,7 @@
                 "Topic 2",
                 "Topic 3"
             ],
+            "teaser": "Ut enim ad minim veniam,",
             "products": [
                 "Product 1",
                 "Product 2",

--- a/test/specs/blog/post_html.json
+++ b/test/specs/blog/post_html.json
@@ -5,6 +5,8 @@
             "author": "James Fox",
             "title": "Header 1",
             "date": 1564617600,
+            "products": [],
+            "teaser": "Ut enim ad minim veniam,",
             "topics": [
                 "Topic 1",
                 "Topic 2",


### PR DESCRIPTION
fixes #37

BREAKING CHANGE: new helix-index.yaml format

- the property can be single or multi value, based on the name:
  `value` creates a single value property,
  `values` creates an array.

  eg:

  ```
  properties:
    title:
      select: main > .title
      value: textContent(el)
    topics:
      select: main > .topic
      values: textContent(el)
  ```

- the `value` or `values` epression is now a proper javascript like
  expression, using [jesp](http://jsep.from.so/) to parse the tree
  it supports functions, literals and variables so far. eg:

  ```
    value: words(textContent(el), 0, 10)
  ```

- the _variable context_ for the expression evaluation currently
  contains: `el`, `logger` and all the helper functions:
  `parseTimestamp`, `attribute`, `textContent`, `match`, `words`.

- the helper functions receive the arguments as specified (no, `element`
  injection) and need to return an result array.

- the `context.el` is an array containing the results of the
  `document.querySelectorAll()` of the proprties `select` expression.
  this allows to build more complext helpers that can operate on
  multiple elements. like extracting the words from multiple paragraphs.