### PR TITLE
fix: post-deploy currently fails because it looks for master branch

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -6,7 +6,7 @@ version: 1
 indices:
   blog-posts:
     source: html
-    fetch: https://{repo}-{owner}.project-helix.page{path}
+    fetch: https://{ref}--{repo}--{owner}.project-helix.page{path}
     properties:
       author:
         select: main > div:nth-of-type(3) > p:nth-of-type(1)
@@ -49,7 +49,7 @@ indices:
           replace(path, '/test/specs/', '/')
   blog-posts-flat:
     source: html
-    fetch: https://{repo}-{owner}.project-helix.page{path}
+    fetch: https://{ref}--{repo}--{owner}.project-helix.page{path}
     properties:
       author:
         select: main > div:nth-of-type(3) > p:nth-of-type(1)

--- a/src/html_json.js
+++ b/src/html_json.js
@@ -65,7 +65,7 @@ const helpers = {
  */
 async function fetchHTML(params, indices) {
   const {
-    owner, repo, path, log,
+    owner, repo, ref, path, log,
   } = params;
 
   // Create our result where we'll store the HTML responses
@@ -75,7 +75,11 @@ async function fetchHTML(params, indices) {
       // eslint-disable-next-line no-param-reassign
       prev[name] = {
         index,
-        url: index.fetch.replace(/\{owner\}/g, owner).replace(/\{repo\}/g, repo).replace(/\{path\}/g, path),
+        url: index.fetch
+          .replace(/\{owner\}/g, owner)
+          .replace(/\{repo\}/g, repo)
+          .replace(/\{ref\}/g, ref)
+          .replace(/\{path\}/g, path),
       };
       return prev;
     }, {});

--- a/test/html_json.test.js
+++ b/test/html_json.test.js
@@ -24,7 +24,7 @@ const SPEC_ROOT = p.resolve(__dirname, 'specs');
 
 describe('HTML Indexing with hlx up', () => {
   before(async () => {
-    nock('https://helix-index-pipelines-adobe.project-helix.page')
+    nock('https://main--helix-index-pipelines--adobe.project-helix.page')
       .get((uri) => uri.startsWith('/test/specs/hlx_up'))
       .reply(200, (uri) => {
         const path = p.resolve(SPEC_ROOT, 'hlx_up', p.basename(uri).replace(/\.md$/, '.html'));

--- a/test/post-deploy.js
+++ b/test/post-deploy.js
@@ -24,6 +24,7 @@ describe('Post-Deploy Tests', () => {
   let wskOpts = {};
   let actionName;
   let { version } = pkgJson;
+  let branch = 'main';
 
   before(() => {
     wskOpts = {
@@ -32,6 +33,7 @@ describe('Post-Deploy Tests', () => {
     };
     if (process.env.CIRCLE_BUILD_NUM && process.env.CIRCLE_BRANCH !== 'main') {
       version = `ci${process.env.CIRCLE_BUILD_NUM}`;
+      branch = process.env.CIRCLE_BRANCH;
     }
     // eslint-disable-next-line no-template-curly-in-string
     actionName = pkgJson.wsk.name.replace('${version}', version);
@@ -76,7 +78,7 @@ describe('Post-Deploy Tests', () => {
       params: {
         owner: 'adobe',
         repo: 'helix-index-pipelines',
-        ref: 'main',
+        ref: branch,
         path: '/test/specs/example-post.html',
       },
     });
@@ -99,7 +101,7 @@ describe('Post-Deploy Tests', () => {
       params: {
         owner: 'adobe',
         repo: 'helix-index-pipelines',
-        ref: 'main',
+        ref: branch,
         path: '/notfound.html',
       },
     });


### PR DESCRIPTION
`semantic-release` workflow fails in the `post-deploy` testing phase, because it tries to fetch HTML from the `master` branch of its own `helix-index-pipelines` github repo.