### PR TITLE
fix: allow match on attribute value

### DIFF
--- a/src/html_json.js
+++ b/src/html_json.js
@@ -37,9 +37,10 @@ const helpers = {
     const regex = new RegExp(re, 'g');
     elements.forEach((el) => {
       let m;
+      const content = typeof el === 'string' ? el : el.textContent;
 
       // eslint-disable-next-line no-cond-assign
-      while ((m = regex.exec(el.textContent)) !== null) {
+      while ((m = regex.exec(content)) !== null) {
         result.push(m[m.length - 1]);
       }
     });


### PR DESCRIPTION
`match` helper currently expects an HTMLElement array to operate on. Added support to operate on attribute *values*, as in:
```
match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
```
This matches a regex against the `content` attribute value of an HTMLElement.